### PR TITLE
Prepare for self-hosted CI

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
 MAINTAINER citra
+RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools wget git ccache cmake

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER citra
-RUN mkdir -p /tmp/pkgs
+RUN useradd -m -s /bin/bash citra && mkdir -p /tmp/pkgs
 COPY install_package.py /tmp/pkgs
 RUN apt-get update && apt-get install -y build-essential wget git python-launchpadlib ccache
 RUN cd /tmp/pkgs && python2 install_package.py \

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y build-essential wget git python-launchp
 RUN cd /tmp/pkgs && python2 install_package.py \
     libsdl2-dev 2.0.7+dfsg1-3ubuntu1 bionic          \
     qtbase5-dev 5.9.3+dfsg-0ubuntu2 bionic           \
+    qttools5-dev-tools 5.9.5-0ubuntu1 bionic         \
     libqt5opengl5-dev 5.9.3+dfsg-0ubuntu2 bionic     \
     qt5-qmltooling-plugins 5.9.3-0ubuntu1 bionic     \
     qtdeclarative5-dev 5.9.3-0ubuntu1 bionic         \

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER citra
+RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get install -y gpg wget git python3-pip ccache g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake
 # workaround broken headers in Ubuntu MinGW package
 COPY errno.h /usr/x86_64-w64-mingw32/include/

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine
+RUN useradd -m -s /bin/bash citra
 RUN apk update && apk add build-base cmake python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
 RUN pip3 install transifex-client


### PR DESCRIPTION
Add Qt 5 tools package.

To make `frozen` container build correctly with `i18n` support

EDIT:
commit 2 added a non-privileged user to the container image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/build-environments/3)
<!-- Reviewable:end -->
