### PR TITLE
Fix transifex push

### DIFF
--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine
 RUN adduser -u 1000 -D -s /bin/bash citra
-RUN apk update && apk add build-base cmake python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
+RUN apk update && apk add build-base cmake git python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
 RUN pip3 install transifex-client


### PR DESCRIPTION
Git is now needed for cloning libzmq on cmake configuration.