### PR TITLE
linux-mingw: update Dockerfile

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -4,7 +4,8 @@ RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get install -y gpg wget git python3-pip ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake
 # workaround broken headers in Ubuntu MinGW package
 COPY errno.h /usr/x86_64-w64-mingw32/include/
-# HACK: the repository does not contain necessary packages for 18.04, we'll use packages for 17.10 for now
-RUN echo 'deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu artful main ' > /etc/apt/sources.list.d/extras.list
+# add mingw-w64 auxiliary ppa repository
+RUN echo 'deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu bionic main ' > /etc/apt/sources.list.d/extras.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv '72931B477E22FEFD47F8DECE02FE5F12ADDE29B2' && apt-get update
 RUN apt-get install -y sdl2-mingw-w64 qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64
+RUN pip3 install pefile


### PR DESCRIPTION
The upstream PPA repository finally updated all the packages to match `bionic beaver (18.04)`.

This change rendered the previous hack no longer usable. However, why not just use the newer one instead? :smiley:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/build-environments/11)
<!-- Reviewable:end -->
