### PR TITLE
linux-osxcross: new, cross-compile for macOS

### DIFF
--- a/linux-osxcross/Dockerfile
+++ b/linux-osxcross/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:18.04
+MAINTAINER citra
+RUN useradd -m -s /bin/bash citra
+RUN apt-get update && apt-get -y full-upgrade
+RUN apt-get install -y make cmake ccache clang xz-utils wget p7zip-full git qt5-default qttools5-dev-tools
+COPY osxcross-setup.sh /tmp/
+RUN bash -e /tmp/osxcross-setup.sh
+ENV PATH="${PATH}:/opt/osxcross/bin/"
+COPY toolchain.cmake /opt/osxcross/

--- a/linux-osxcross/osxcross-setup.sh
+++ b/linux-osxcross/osxcross-setup.sh
@@ -5,9 +5,9 @@ SDL2_REPACK='https://liushuyu.b-cdn.net/SDL2-2.0.9.macos.tar.xz'
 QT_SDK_REPO='https://download.qt.io/online/qtsdkrepository/mac_x64/desktop'
 
 # navigate to the URL above to find out the following parameters
-QT_RELEASE='5.12.0'
+QT_RELEASE='5.13.0'
 QT_RL='0' # usually zero
-QT_BUILD='201812040350'
+QT_BUILD='201902110737'
 QT_COMPONENTS=('qtbase' 'qtimageformats' 'qtmacextras' 'qtmultimedia' 'qttools')
 
 mkdir -p osxcross
@@ -15,9 +15,19 @@ pushd osxcross
 
 export PATH="/opt/osxcross/bin/:$PATH"
 
+# sdl2 and osxcross
 echo 'Downloading OSXCross toolchain and SDL2 binary...'
 wget -q "${OC_PREBUILT}" "${SDL2_REPACK}"
 
+# ffmpeg
+FFMPEG_VER='4.1.1'
+for i in 'shared' 'dev'; do
+  echo "Downloading and extracting ffmpeg (${i})..."
+  wget -q -c "https://ffmpeg.zeranoe.com/builds/macos64/${i}/ffmpeg-${FFMPEG_VER}-macos64-${i}.zip"
+  7z x "ffmpeg-${FFMPEG_VER}-macos64-${i}.zip" > /dev/null
+done
+
+# Qt
 QT_VERSION="${QT_RELEASE//./}"
 for i in "${QT_COMPONENTS[@]}"; do
   echo "Downloading Qt prebuilt binary (${i})..."
@@ -42,12 +52,22 @@ tar xf "${OC_PREBUILT}" -C /
 echo 'Extracting SDL2 binary...'
 tar xf "${SDL2_REPACK}"
 
+echo "Copying ffmpeg ${FFMPEG_VER} files to sysroot..."
 
-cp -r 'SDL2/SDL2.framework' '/opt/osxcross/macports/pkgs/opt/local/lib/'
+cp -v "ffmpeg-${FFMPEG_VER}-macos64-shared"/bin/*.dylib /opt/osxcross/macports/pkgs/opt/local/lib/
+cp -vr "ffmpeg-${FFMPEG_VER}-macos64-dev"/include /opt/osxcross/macports/pkgs/opt/local/
+FFMPEG_LIBS=$(find "/opt/osxcross/macports/pkgs/opt/local/lib/" -name 'libav*.dylib')
+# cmake won't find the ffmpeg libs if the files contain version numbers
+for i in ${FFMPEG_LIBS}; do
+    ln -sv "${i}" "${i%.*.*}.dylib"
+done
+
+echo 'Copying SDL2 binaries...'
+cp -rv 'SDL2/SDL2.framework' '/opt/osxcross/macports/pkgs/opt/local/lib/'
 # for some reasons, cmake is very confused if you don't put framework in :/System/Library/
 # even from debug messages, cmake searched :/opt/loca/lib/ but it just don't feel like
 # to use that
-ln -s '/opt/osxcross/macports/pkgs/opt/local/lib/SDL2.framework' /opt/osxcross/SDK/MacOSX*.sdk/System/Library/Frameworks/
+ln -sv '/opt/osxcross/macports/pkgs/opt/local/lib/SDL2.framework' /opt/osxcross/SDK/MacOSX*.sdk/System/Library/Frameworks/
 
 echo "Building dependency resolvers..."
 
@@ -58,6 +78,7 @@ popd
 
 rm -rf '/opt/osxcross/macports/pkgs/opt/local/bin/'*
 
+echo 'Replacing Qt Tools with native binaries...'
 for i in 'moc' 'qdbuscpp2xml' 'qdbusxml2cpp' 'qlalr' 'qmake' 'rcc' 'uic' 'lconvert' 'lrelease' 'lupdate'; do
   ln -sv "$(which $i)" '/opt/osxcross/macports/pkgs/opt/local/bin/'
 done

--- a/linux-osxcross/osxcross-setup.sh
+++ b/linux-osxcross/osxcross-setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash -e
+
+OC_PREBUILT='https://liushuyu.b-cdn.net/osxcross-10.14-ubuntu-18.04-llvm6.tar.xz'
+SDL2_REPACK='https://liushuyu.b-cdn.net/SDL2-2.0.9.macos.tar.xz'
+QT_SDK_REPO='https://download.qt.io/online/qtsdkrepository/mac_x64/desktop'
+
+# navigate to the URL above to find out the following parameters
+QT_RELEASE='5.12.0'
+QT_RL='0' # usually zero
+QT_BUILD='201812040350'
+QT_COMPONENTS=('qtbase' 'qtimageformats' 'qtmacextras' 'qtmultimedia' 'qttools')
+
+mkdir -p osxcross
+pushd osxcross
+
+export PATH="/opt/osxcross/bin/:$PATH"
+
+echo 'Downloading OSXCross toolchain and SDL2 binary...'
+wget -q "${OC_PREBUILT}" "${SDL2_REPACK}"
+
+QT_VERSION="${QT_RELEASE//./}"
+for i in "${QT_COMPONENTS[@]}"; do
+  echo "Downloading Qt prebuilt binary (${i})..."
+  wget -q "${QT_SDK_REPO}/qt5_${QT_VERSION}/qt.qt5.${QT_VERSION}.clang_64/${QT_RELEASE}-${QT_RL}-${QT_BUILD}${i}-MacOS-MacOS_10_13-Clang-MacOS-MacOS_10_13-X86_64.7z"
+done
+
+mkdir -p qt5 && cd qt5
+for i in ../*.7z; do
+  echo "Extracting ${i}..."
+  7z x "${i}"
+done
+mkdir -p '/opt/osxcross/macports/pkgs/opt/local/'
+cp -r "${QT_RELEASE}/clang_64"/* '/opt/osxcross/macports/pkgs/opt/local/'
+cd ..
+
+# extract the files
+OC_PREBUILT="$(basename ${OC_PREBUILT})"
+SDL2_REPACK="$(basename ${SDL2_REPACK})"
+
+echo 'Extracting OSXCross toolchain...'
+tar xf "${OC_PREBUILT}" -C /
+echo 'Extracting SDL2 binary...'
+tar xf "${SDL2_REPACK}"
+
+
+cp -r 'SDL2/SDL2.framework' '/opt/osxcross/macports/pkgs/opt/local/lib/'
+# for some reasons, cmake is very confused if you don't put framework in :/System/Library/
+# even from debug messages, cmake searched :/opt/loca/lib/ but it just don't feel like
+# to use that
+ln -s '/opt/osxcross/macports/pkgs/opt/local/lib/SDL2.framework' /opt/osxcross/SDK/MacOSX*.sdk/System/Library/Frameworks/
+
+echo "Building dependency resolvers..."
+
+git clone --depth=1 'https://github.com/liushuyu/osxcross-extras'
+pushd 'osxcross-extras'
+./install_extras.sh
+popd
+
+rm -rf '/opt/osxcross/macports/pkgs/opt/local/bin/'*
+
+for i in 'moc' 'qdbuscpp2xml' 'qdbusxml2cpp' 'qlalr' 'qmake' 'rcc' 'uic' 'lconvert' 'lrelease' 'lupdate'; do
+  ln -sv "$(which $i)" '/opt/osxcross/macports/pkgs/opt/local/bin/'
+done
+
+popd
+rm -rf osxcross
+
+# suicide
+rm -f "$0"

--- a/linux-osxcross/toolchain.cmake
+++ b/linux-osxcross/toolchain.cmake
@@ -1,0 +1,66 @@
+# OSXCross toolchain
+
+macro(osxcross_getconf VAR)
+  if(NOT ${VAR})
+    set(${VAR} "$ENV{${VAR}}")
+    if(${VAR})
+      set(${VAR} "${${VAR}}" CACHE STRING "${VAR}")
+      message(STATUS "Found ${VAR}: ${${VAR}}")
+    else()
+      message(FATAL_ERROR "Cannot determine \"${VAR}\"")
+    endif()
+  endif()
+endmacro()
+
+osxcross_getconf(OSXCROSS_HOST)
+osxcross_getconf(OSXCROSS_TARGET_DIR)
+osxcross_getconf(OSXCROSS_TARGET)
+osxcross_getconf(OSXCROSS_SDK)
+
+set(CMAKE_SYSTEM_NAME "Darwin")
+string(REGEX REPLACE "-.*" "" CMAKE_SYSTEM_PROCESSOR "${OSXCROSS_HOST}")
+
+# specify the cross compiler
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
+  set(CMAKE_C_COMPILER "${OSXCROSS_TARGET_DIR}/bin/o32-clang")
+  set(CMAKE_CXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/o32-clang++")
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(CMAKE_C_COMPILER "${OSXCROSS_TARGET_DIR}/bin/o64-clang")
+  set(CMAKE_CXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/o64-clang++")
+else()
+  message(FATAL_ERROR "Unrecognized target architecture")
+endif()
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH
+  "${OSXCROSS_SDK}"
+  "${OSXCROSS_TARGET_DIR}/macports/pkgs/opt/local"
+# HACK: Qt 5, loves to use absolute path which screws things up
+  "/")
+
+# ccache wrapper
+OPTION(USE_CCACHE "Use ccache for compilation" OFF)
+IF(USE_CCACHE)
+    FIND_PROGRAM(CCACHE ccache)
+    IF (CCACHE)
+        MESSAGE(STATUS "Using ccache found in PATH")
+        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
+        SET_PROPERTY(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})
+    ELSE(CCACHE)
+        MESSAGE(WARNING "USE_CCACHE enabled, but no ccache found")
+    ENDIF(CCACHE)
+ENDIF(USE_CCACHE)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CMAKE_AR "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-ar" CACHE FILEPATH "ar")
+set(CMAKE_RANLIB "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-ranlib" CACHE FILEPATH "ranlib")
+set(CMAKE_INSTALL_NAME_TOOL "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-install_name_tool" CACHE FILEPATH "install_name_tool")
+
+set(ENV{PKG_CONFIG_LIBDIR} "${OSXCROSS_TARGET_DIR}/macports/pkgs/opt/local/lib/pkgconfig")
+set(ENV{PKG_CONFIG_SYSROOT_DIR} "${OSXCROSS_TARGET_DIR}/macports/pkgs")


### PR DESCRIPTION
This changeset contains scripts to create an image for building macOS binaries in Linux container.

#### Things to note:

1. The toolchain binary package (`OSXCross`) is built, packaged and hosted by me. If you don't trust this binary package, it's totally fine. (see 2)
2. The links for downloading binary packages might become invalid. For the prebuilt OSXCross package, you can roll your own; for the others, see the comments in the scripts.
3. The resulting container image is huge (~2.1 GB), and some CI services may have a capacity constraint on this (Travis CI: ~18GB total virtual disk space).
4. Because of (1) and (2), you might want to roll the OSXCross package on some CI services. But from my experience, please try to do it locally with a Docker instance. On Travis CI, the build time could range from 50 minutes to 60 + minutes (times out). CI services will terminate your build if the build time is so long.
5. SDL 2 package is repackaged from the official image; same rules apply from (2).
6. `macdeployqt` is heavily modified and it can deploy correctly per my tests despite it will __spit out some errors__.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/build-environments/12)
<!-- Reviewable:end -->
