### PR TITLE
linux-mingw: add ffmpeg as dependency

### DIFF
--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER citra
-RUN useradd -m -s /bin/bash citra
+RUN useradd -m -s /bin/bash citra && mkdir -p /tmp/pkgs
 RUN apt-get update && apt-get install -y gpg wget git python3-pip ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake
 # workaround broken headers in Ubuntu MinGW package
 COPY errno.h /usr/x86_64-w64-mingw32/include/
@@ -8,4 +8,5 @@ COPY errno.h /usr/x86_64-w64-mingw32/include/
 RUN echo 'deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu bionic main ' > /etc/apt/sources.list.d/extras.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv '72931B477E22FEFD47F8DECE02FE5F12ADDE29B2' && apt-get update
 RUN apt-get install -y sdl2-mingw-w64 qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64
-RUN pip3 install pefile
+COPY mingw-setup.sh /tmp/pkgs
+RUN cd /tmp/pkgs && bash -e mingw-setup.sh

--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash -e
+# install pefile
+pip3 install pefile
+
+# ffmpeg
+FFMPEG_VER='4.1'
+for i in 'shared' 'dev'; do
+  echo "Downloading ffmpeg (${i})..."
+  wget -q -c "https://ffmpeg.zeranoe.com/builds/win64/${i}/ffmpeg-${FFMPEG_VER}-win64-${i}.zip"
+  7z x "ffmpeg-${FFMPEG_VER}-win64-${i}.zip" > /dev/null
+done
+
+echo "Copying ffmpeg ${FFMPEG_VER} files to sysroot..."
+cp -v "ffmpeg-${FFMPEG_VER}-win64-shared"/bin/*.dll /usr/x86_64-w64-mingw32/lib/
+cp -vr "ffmpeg-${FFMPEG_VER}-win64-dev"/include /usr/x86_64-w64-mingw32/
+cp -v "ffmpeg-${FFMPEG_VER}-win64-dev"/lib/*.{a,def} /usr/x86_64-w64-mingw32/lib/
+
+# remove the directory
+ABS_PATH="$(readlink -f $0)"
+rm -rf "$(dirname ${ABS_PATH})"


### PR DESCRIPTION
Added a new script to include `ffmpeg` binaries in the `linux-mingw` container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/build-environments/13)
<!-- Reviewable:end -->
