### PR TITLE
Add libavcodec-dev, libavformat-dev and libswscale-dev

### DIFF
--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 MAINTAINER citra
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools wget git ccache cmake flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
+RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavformat-dev libswscale-dev wget git ccache cmake flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
 RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 RUN flatpak install -y flathub org.kde.Platform//5.11 org.kde.Sdk//5.11 org.freedesktop.Sdk.Extension.gcc7

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu:18.04
 MAINTAINER citra
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools wget git ccache cmake
+RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavformat-dev libswscale-dev wget git ccache cmake

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -11,5 +11,8 @@ RUN cd /tmp/pkgs && python2 install_package.py \
     qtdeclarative5-dev 5.9.3-0ubuntu1 bionic         \
     qtmultimedia5-dev 5.9.3-0ubuntu3 bionic          \
     libicu57 57.1-6ubuntu0.2 bionic                  \
-    cmake 3.10.2-1ubuntu2 bionic
+    cmake 3.10.2-1ubuntu2 bionic                     \
+    libavcodec-dev 7:3.4.4-0ubuntu0.18.04.1 bionic   \
+    libavformat-dev 7:3.4.4-0ubuntu0.18.04.1 bionic  \
+    libswscale-dev 7:3.4.4-0ubuntu0.18.04.1 bionic
 RUN rm -rf /tmp/pkgs

--- a/linux-frozen/install_package.py
+++ b/linux-frozen/install_package.py
@@ -20,7 +20,7 @@ def get_url(pkg, distro):
     build_ref = launchpad.archives.getByReference(reference='ubuntu').getPublishedBinaries(
         binary_name=pkg[0], distro_arch_series='https://api.launchpad.net/devel/ubuntu/' + distro + '/amd64', version=pkg[1], exact_match=True, order_by_date=True).entries[0]
     build_link = build_ref['build_link']
-    deb_name = '{}_{}_{}.deb'.format(pkg[0], pkg[1], 'amd64' if build_ref['architecture_specific'] else 'all')
+    deb_name = '{}_{}_{}.deb'.format(pkg[0], pkg[1].split(':', 1)[-1], 'amd64' if build_ref['architecture_specific'] else 'all')
     deb_link = build_link + '/+files/' + deb_name
     return [deb_link, deb_name]
 
@@ -28,7 +28,7 @@ def get_url(pkg, distro):
 def list_dependencies(deb_file):
     t = subprocess.check_output(
         ['bash', '-c', '(dpkg -I {} | grep -oP "^ Depends\: \K.*$") || true'.format(deb_file)])
-    deps = [i.strip() for i in t.split(',')]
+    deps = [i.split('|')[0].strip() for i in t.split(',')]
     equals_re = re.compile(r'^(.*) \(= (.*)\)$')
     return [equals_re.sub(r'\1=\2', i).split('=') for i in filter(equals_re.match, deps)]
 

--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -10,6 +10,19 @@ wget -q "${MINGW_URL}" -O 'mingw.7z'
 7z x 'mingw.7z' "${TARGET_DIR}"lib{mf,mfplat,mfuuid}.a
 cp -rv "${TARGET_DIR}"/* '/usr/x86_64-w64-mingw32/lib/'
 
+# ffmpeg
+FFMPEG_VER='4.1'
+for i in 'shared' 'dev'; do
+  echo "Downloading ffmpeg (${i})..."
+  wget -q -c "https://ffmpeg.zeranoe.com/builds/win64/${i}/ffmpeg-${FFMPEG_VER}-win64-${i}.zip"
+  7z x "ffmpeg-${FFMPEG_VER}-win64-${i}.zip" > /dev/null
+done
+
+echo "Copying ffmpeg ${FFMPEG_VER} files to sysroot..."
+cp -v "ffmpeg-${FFMPEG_VER}-win64-shared"/bin/*.dll /usr/x86_64-w64-mingw32/lib/
+cp -vr "ffmpeg-${FFMPEG_VER}-win64-dev"/include /usr/x86_64-w64-mingw32/
+cp -v "ffmpeg-${FFMPEG_VER}-win64-dev"/lib/*.{a,def} /usr/x86_64-w64-mingw32/lib/
+
 # remove the directory
 ABS_PATH="$(readlink -f $0)"
 rm -rf "$(dirname ${ABS_PATH})"


### PR DESCRIPTION
For: citra-emu/citra#4602

The install_package script is slightly changed to correctly handle the different version format (with a number followed by `:` in front of the version) and "or" dependencies (separated by `|` in dpkg info)

Added FFmpeg back to linux-mingw script. Original PR is #13