### PR TITLE
Several Improvements

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -3,3 +3,4 @@ LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y git clang-format-6.0
+USER citra

--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER citra
+LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y git clang-format-6.0

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:18.04
 MAINTAINER citra
-RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavformat-dev libswscale-dev wget git ccache cmake flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
+RUN apt-get install -y p7zip-full wget git flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
 RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 RUN flatpak install -y flathub org.kde.Platform//5.12 org.kde.Sdk//5.12

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER citra
+LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full wget git flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
 RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -3,3 +3,4 @@ LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavformat-dev libswscale-dev wget git ccache cmake ninja-build
+USER citra

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER citra
+LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavformat-dev libswscale-dev wget git ccache cmake ninja-build

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER citra
+LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra && mkdir -p /tmp/pkgs
 COPY install_package.py /tmp/pkgs
 RUN apt-get update && apt-get install -y build-essential wget git python-launchpadlib ccache ninja-build

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -16,3 +16,4 @@ RUN cd /tmp/pkgs && python2 install_package.py \
     libavformat-dev 7:3.4.4-0ubuntu0.18.04.1 bionic  \
     libswscale-dev 7:3.4.4-0ubuntu0.18.04.1 bionic
 RUN rm -rf /tmp/pkgs
+USER citra

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -10,3 +10,4 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv '72931B477E22FEFD47F8DEC
 RUN apt-get install -y sdl2-mingw-w64 qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64
 COPY mingw-setup.sh /tmp/pkgs
 RUN cd /tmp/pkgs && bash -e mingw-setup.sh
+USER citra

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER citra
+LABEL maintainer="citraemu"
 RUN useradd -m -s /bin/bash citra && mkdir -p /tmp/pkgs
 RUN apt-get update && apt-get install -y gpg wget git python3-pip ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake ninja-build
 # workaround broken headers in Ubuntu MinGW package

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
+LABEL maintainer="citraemu"
 RUN adduser -u 1000 -D -s /bin/bash citra
 RUN apk update && apk add build-base cmake python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
 RUN pip3 install transifex-client

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -3,3 +3,4 @@ LABEL maintainer="citraemu"
 RUN adduser -u 1000 -D -s /bin/bash citra
 RUN apk update && apk add build-base cmake python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
 RUN pip3 install transifex-client
+USER citra


### PR DESCRIPTION
This PR introduces several improvements to the Dockerfiles.

Notably:

1. Ditched deprecated `MAINTAINER` directive and switched to `LABEL` instead
2. Set the regular user (`name = citra, uid = 1000, gid = 1000`) instead of `root` as the default user to mitigate potential security issues
3. Adjustments to `linux-flatpak` (see below)

#### Adjustments to `Linux-Flatpak` Image

- Removed redundant dependencies in the image `linux-flatpak`. Since Flatpak uses its own GCC and libraries, you don't need to install the system-wide libraries and tools (Flatpak has its own `ccache` and `cmake` as well). 

- Also, it is discovered that Flatpak bundles a copy of `ffmpeg` with FD.o SDK (installed as the dependency of `org.kde.Sdk`) as well (which contains `aac` decoder), and enabling `-DENABLE_FFMPEG` switch will activate the HLE AAC support.

- The resulting image shrunk from 5.51 GB to 3.41 GB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/build-environments/18)
<!-- Reviewable:end -->
