### PR TITLE
linux-flatpak: add sudo for use with Azure Pipelines

### DIFF
--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y p7zip-full wget git flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2
+RUN apt-get install -y p7zip-full wget git flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2 sudo
 RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 RUN flatpak install -y flathub org.kde.Platform//5.12 org.kde.Sdk//5.12


### PR DESCRIPTION
Azure Pipelines will create a normal user inside the Docker container and use this normal user when building.

However, our Flatpak build requires superuser permission to operate (mounting virtual directories, etc). So this PR just simply installs `sudo` into the image.