### PR TITLE
Update mingw sdl to 2.0.12

### DIFF
--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -11,7 +11,7 @@ wget -q "${MINGW_URL}" -O 'mingw.7z'
 cp -rv "${TARGET_DIR}"/* '/usr/x86_64-w64-mingw32/lib/'
 
 # SDL2
-SDL2_VER='2.0.10'
+SDL2_VER='2.0.12'
 wget "https://www.libsdl.org/release/SDL2-devel-${SDL2_VER}-mingw.tar.gz"
 tar -zxf "SDL2-devel-${SDL2_VER}-mingw.tar.gz"
 cd SDL2-${SDL2_VER}/


### PR DESCRIPTION
The update to sld2.0.10 brought our users problems when using non-Nintendo switch controllers, due to the hidapi drivers not differentiating the input-only controllers. There were also a few reports of problems with xbox one controllers.
The library now has functions in place that deduce the controller type based on a database.
From a quick look at the code, the change should fix the current issues with the controller compatibility.
There are also changes to the way xbox360 controllers are handled, as well as added hidapi driver support for gamecube controller adapters, so we should keep an eye on those too.