### PR TITLE
Update Ubuntu version to 20.04

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y git clang-format-6.0 p7zip-full

--- a/linux-flatpak/Dockerfile
+++ b/linux-flatpak/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full wget git flatpak flatpak-builder ca-certificates sshfs curl fuse dnsutils gnupg2 sudo

--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavfilter-dev libavformat-dev libswscale-dev wget git ccache cmake ninja-build

--- a/linux-frozen/Dockerfile
+++ b/linux-frozen/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 RUN mkdir -p /tmp/pkgs
 COPY install_package.py /tmp/pkgs

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 RUN mkdir -p /tmp/pkgs
 RUN apt-get update && apt-get install -y gpg wget git python3-pip ccache p7zip-full g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake ninja-build


### PR DESCRIPTION
With https://github.com/citra-emu/citra/pull/5459, we require a newer CMake version than what is shipped on the Ubuntu 18.04 containers.
This change was already done for the yuzu containers as well and it works fine there.