### PR TITLE
linux-clang-format: Make use of clang-format 10

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -2,4 +2,4 @@ FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y git clang-format-6.0 p7zip-full
+RUN apt-get install -y git clang-format-10.0 p7zip-full


### PR DESCRIPTION
This plays nicer with C++ attributes and is also more up to date.