### PR TITLE
clang-format: Correct package name

### DIFF
--- a/linux-clang-format/Dockerfile
+++ b/linux-clang-format/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:18.04
 LABEL maintainer="citraemu"
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y git clang-format-6.0 p7zip-full
+RUN apt-get install -y git clang-format-10 p7zip-full


### PR DESCRIPTION
The actual package itself has dropped the use of the decimal in the version number.