### PR TITLE
CI: Migrate Image Building Facilities to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,15 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@v1
       name: Setup Docker BuildX system
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      if: (github.ref == 'refs/heads/master') && (github.repository == 'citra-emu/build-environments')
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - uses: docker/build-push-action@v2
       name: Build image
       with:
-        push: false
+        push: ${{ (github.ref == 'refs/heads/master') && (github.repository == 'citra-emu/build-environments') }}
         context: ${{ matrix.image }}
         tags: citraemu/build-environments:${{ matrix.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: 'Citra Docker Image CI'
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["linux-clang-format", "linux-flatpak", "linux-fresh", "linux-frozen", "linux-mingw", "linux-transifex"]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/setup-buildx-action@v1
+      name: Setup Docker BuildX system
+    - uses: docker/build-push-action@v2
+      name: Build image
+      with:
+        push: false
+        context: ${{ matrix.image }}
+        tags: citraemu/build-environments:${{ matrix.image }}

--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -11,7 +11,7 @@ wget -q "${MINGW_URL}" -O 'mingw.7z'
 cp -rv "${TARGET_DIR}"/* '/usr/x86_64-w64-mingw32/lib/'
 
 # SDL2
-SDL2_VER='2.0.12'
+SDL2_VER='2.0.16'
 wget "https://www.libsdl.org/release/SDL2-devel-${SDL2_VER}-mingw.tar.gz"
 tar -zxf "SDL2-devel-${SDL2_VER}-mingw.tar.gz"
 cd SDL2-${SDL2_VER}/
@@ -19,17 +19,16 @@ make install-package arch=x86_64-w64-mingw32 prefix=/usr/x86_64-w64-mingw32;
 cd ..
 
 # ffmpeg
-FFMPEG_VER='4.1'
-for i in 'shared' 'dev'; do
-  echo "Downloading ffmpeg (${i})..."
-  wget -q -c "https://ffmpeg.zeranoe.com/builds/win64/${i}/ffmpeg-${FFMPEG_VER}-win64-${i}.zip"
-  7z x "ffmpeg-${FFMPEG_VER}-win64-${i}.zip" > /dev/null
-done
+FFMPEG_VER='4.4'
+FILENAME="ffmpeg-n${FFMPEG_VER}-151-g5e61fce832-win64-gpl-shared-${FFMPEG_VER}"
+echo "Downloading ffmpeg (${FFMPEG_VER})..."
+wget -q -c "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-09-13-12-21/${FILENAME}.zip"
+7z x "${FILENAME}.zip"
 
 echo "Copying ffmpeg ${FFMPEG_VER} files to sysroot..."
-cp -v "ffmpeg-${FFMPEG_VER}-win64-shared"/bin/*.dll /usr/x86_64-w64-mingw32/lib/
-cp -vr "ffmpeg-${FFMPEG_VER}-win64-dev"/include /usr/x86_64-w64-mingw32/
-cp -v "ffmpeg-${FFMPEG_VER}-win64-dev"/lib/*.{a,def} /usr/x86_64-w64-mingw32/lib/
+cp -v "${FILENAME}"/bin/*.dll /usr/x86_64-w64-mingw32/lib/
+cp -vr "${FILENAME}"/include /usr/x86_64-w64-mingw32/
+cp -v "${FILENAME}"/lib/*.{a,def} /usr/x86_64-w64-mingw32/lib/
 
 # remove the directory
 ABS_PATH="$(readlink -f $0)"


### PR DESCRIPTION
Since Docker Hub now started to charge for their CI even for FOSS projects, we now need to bring our own CI system and then push the artifacts to the Docker Hub.

This Pull Request adds GitHub Actions as the CI and pushes the artifacts to the Docker Hub when needed.