### PR TITLE
Update transifex to run on a newer debian release

### DIFF
--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 LABEL maintainer="citraemu"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y full-upgrade


### PR DESCRIPTION
fixes the cmake version errors.