### PR TITLE
maybe fix dubious ownership issues

### DIFF
--- a/linux-fresh/Dockerfile
+++ b/linux-fresh/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:22.04
 LABEL maintainer="citraemu"
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Create a user account citra (UID 1027) that the container will run as
+RUN useradd -m -u 1027 -s /bin/bash citra 
 RUN apt-get update && apt-get -y full-upgrade
 RUN apt-get install -y p7zip-full build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools libavcodec-dev libavfilter-dev libavformat-dev libswscale-dev wget git ccache cmake ninja-build

--- a/linux-mingw/Dockerfile
+++ b/linux-mingw/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="citraemu"
 # Add mingw-repo "ownstuff" is a AUR with an up to date mingw64
 # Runs pacman -Syu twice in order to work around pacman issues where the first run only updates the
 # current distro packages, and the second run actually pulls the updates from the repos.
-RUN useradd -m -u 1027 -s /bin/bash yuzu && mkdir -p /tmp/pkgs && \
+RUN useradd -m -u 1027 -s /bin/bash citra && mkdir -p /tmp/pkgs && \
     echo "[ownstuff]" >> /etc/pacman.conf && \
     echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf && \
     echo "Server = https://martchus.no-ip.biz/repo/arch/ownstuff/os/\$arch" >> /etc/pacman.conf && \


### PR DESCRIPTION
After fixing the other CI issues in the main repo, the following error remains:
`fatal: detected dubious ownership in repository at '/__w/citra/citra'`
after this is merged I'll test out using the same `chown` commands as yuzu.