### PR TITLE
Port yuzu-emu/build-environments#62: "transifex: New transifex client"

### DIFF
--- a/linux-mingw/mingw-setup.sh
+++ b/linux-mingw/mingw-setup.sh
@@ -3,8 +3,8 @@
 pip3 install pefile
 
 # ffmpeg
-FFMPEG_VER='5.1.2'
-LINK_PATH="autobuild-2023-02-17-12-38/ffmpeg-n5.1.2-12-g7268323193-win64-gpl-shared-5.1"
+FFMPEG_VER='6.0'
+LINK_PATH="autobuild-2023-03-31-12-50/ffmpeg-n6.0-11-g3980415627-win64-gpl-shared-6.0"
 FILENAME="${LINK_PATH##*/}"
 echo "Downloading ffmpeg (${FFMPEG_VER})..."
 wget -c "https://github.com/BtbN/FFmpeg-Builds/releases/download/${LINK_PATH}.zip"

--- a/linux-transifex/Dockerfile
+++ b/linux-transifex/Dockerfile
@@ -5,8 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV CMAKE_VER=3.22.6
 
 RUN apt-get update && apt-get -y full-upgrade
-RUN apt-get install -y git p7zip-full libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools python3-pip cmake curl
-RUN pip3 install transifex-client
+RUN apt-get install -y git p7zip-full libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools python3-pip cmake curl unzip zip
+RUN curl -O -L https://github.com/transifex/cli/releases/latest/download/tx-linux-amd64.tar.gz && tar xf tx-linux-amd64.tar.gz tx && mv tx /usr/bin/tx && rm tx-linux-amd64.tar.gz
 
 # Install CMake from upstream
 RUN cd /tmp


### PR DESCRIPTION
See https://github.com/yuzu-emu/build-environments/pull/62 for more details.

Original description:
New client uses new API. Same great name, but in go instead of python

Configuration also changed, so related to https://github.com/yuzu-emu/yuzu/pull/9058